### PR TITLE
Add links back to PyHC website

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -7,7 +7,7 @@
 # http://www.sphinx-doc.org/en/master/config
 
 # -- Path setup --------------------------------------------------------------
-
+ 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -20,7 +20,7 @@ import pathlib
 
 # -- Project information -----------------------------------------------------
 
-project = 'Python in Heliophysics Community (PyHC) Tutorials'
+project = 'PyHC Tutorials'
 copyright = '2018, PyHC'
 author = 'PyHC'
 

--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,7 @@ import pathlib
 # -- Project information -----------------------------------------------------
 
 project = 'PyHC Tutorials'
-copyright = '2018, PyHC'
+copyright = '2021, PyHC'
 author = 'PyHC'
 
 # The short X.Y version

--- a/conf.py
+++ b/conf.py
@@ -7,7 +7,7 @@
 # http://www.sphinx-doc.org/en/master/config
 
 # -- Path setup --------------------------------------------------------------
- 
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/gallery/README.txt
+++ b/gallery/README.txt
@@ -2,6 +2,8 @@
 Python in Heliophysics Community Gallery
 ========================================
 
+`Back to the Main Site <https://heliopython.org>`_
+
 A collection of examples and tutorials for using Python for Heliophysics. 
 New examples can be added by following the guide in the `README <https://github.com/heliophysicsPy/gallery/blob/master/README.md>`_.
 

--- a/index.rst
+++ b/index.rst
@@ -6,3 +6,5 @@ Welcome to the Python in Heliophysics Gallery
    :glob:
 
    generated/gallery/index
+
+* `Back to the Main Site <https://heliopython.org>`_


### PR DESCRIPTION
Closes [#152](https://github.com/heliophysicsPy/heliophysicsPy.github.io/issues/152)
Closes #20 

We weren't linking back to the main site anywhere. Now we are, in two places. Sphinx generates websites very differently than Jekyll (used by the main site), and this was the best I could figure out how to do. Think it's fine?

**On the front page below the title:**
![Screen Shot 2021-05-20 at 3 35 39 PM](https://user-images.githubusercontent.com/14846863/119051989-2786d680-b981-11eb-899d-06756d202ae5.png)

------

**In the table of contents:**
![Screen Shot 2021-05-20 at 3 35 51 PM](https://user-images.githubusercontent.com/14846863/119052036-353c5c00-b981-11eb-9c17-6507d012d3e6.png)

